### PR TITLE
feat: input shortcuts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@story-cms/kit",
-  "version": "0.2.2",
+  "version": "0.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@story-cms/kit",
-      "version": "0.2.2",
+      "version": "0.3.1",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.697.0",
         "@aws-sdk/lib-storage": "^3.697.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@story-cms/kit",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src/backend/stubs/controllers/chapters_controller.stub
+++ b/src/backend/stubs/controllers/chapters_controller.stub
@@ -50,7 +50,7 @@ export default class ChaptersController {
 
     const chapter = await Chapter.query().where(specifier).firstOrFail();
 
-    return { number: chapter.number, bundle: chapter.bundle };
+    return { number: chapter.number, bundle: chapter.escapedBundle };
   }
 
   public async range(ctx: HttpContext) {

--- a/src/backend/stubs/models/chapter.stub
+++ b/src/backend/stubs/models/chapter.stub
@@ -38,6 +38,14 @@ export default class Chapter extends BaseModel {
     return start;
   }
 
+  public get escapedBundle() {
+    const start =
+      typeof this.bundle === 'string' ? this.bundle : JSON.stringify(this.bundle);
+    const cleaned = start.replace(/\u00A0/g, '\\\\u00A0');
+    const parsed = JSON.parse(cleaned);
+    return parsed;
+  }
+
   public get index(): IndexItem {
     return {
       number: this.number,

--- a/src/backend/stubs/tests/rest.stub
+++ b/src/backend/stubs/tests/rest.stub
@@ -4,6 +4,10 @@
 @authority = http://localhost:3333
 
 ###
+GET {{ authority }}/api/v1/chapter/1 HTTP/1.1
+Accept: application/json
+
+###
 GET \{\{ authority \}\}/api/v1/preview/1 HTTP/1.1
 Content-Type: application/json
 Accept: application/json

--- a/src/frontend/shared/helpers.ts
+++ b/src/frontend/shared/helpers.ts
@@ -26,6 +26,11 @@ export const commonProps = {
   },
 };
 
+export const expandShortcuts = (text: string) => {
+  // tilde -> non-breaking space character
+  return text.replace(/~/g, '\u00A0');
+};
+
 export const padZero = (value: number): string => (value > 9 ? `${value}` : `0${value}`);
 
 export const formatDate = (value: string): string => {


### PR DESCRIPTION
Card: https://trello.com/c/APSfgxaQ/723-non-breaking-spaces
This PR introduce the feature of shortcuts during text input. 
The first implemented shortcut is to use a tilde to insert a non-breaking space into the text. The shortcut is applied to string and markdown fields.
The chapter model is also adapted to escape the non-breaking space and this is applied when the model is retrieved for api responses.